### PR TITLE
Define SIGUNUSED (for legacy compatibility)

### DIFF
--- a/src/inc/tp-timers.h
+++ b/src/inc/tp-timers.h
@@ -26,7 +26,9 @@ typedef void (*tpSktActor)(int, void *);
 
 /* Signal handler stuff */
 typedef void (*tpSigActor)(int);
+#ifndef SIGUNUSED
 #define SIGUNUSED SIGSYS
+#endif
 #define TP_MAXSIGNALS       (SIGUNUSED + 1)
 
 /* Public function prototypes */

--- a/src/inc/tp-timers.h
+++ b/src/inc/tp-timers.h
@@ -26,6 +26,7 @@ typedef void (*tpSktActor)(int, void *);
 
 /* Signal handler stuff */
 typedef void (*tpSigActor)(int);
+#define SIGUNUSED SIGSYS
 #define TP_MAXSIGNALS       (SIGUNUSED + 1)
 
 /* Public function prototypes */


### PR DESCRIPTION
I was having issues trying to compile FreeBFD on a Ubuntu 18.04 machine:
```
In file included from src/core/tp-timers.c:23:0:
src/inc/tp-timers.h:29:30: error: ‘SIGUNUSED’ undeclared here (not in a function); did you mean ‘SI_USER’?
 #define TP_MAXSIGNALS       (SIGUNUSED + 1)
                              ^
src/core/tp-timers.c:47:29: note: in expansion of macro ‘TP_MAXSIGNALS’
 static tpSigActor sigActors[TP_MAXSIGNALS];
                             ^~~~~~~~~~~~~
src/core/tp-timers.c:47:19: error: ‘sigActors’ defined but not used [-Werror=unused-variable]
 static tpSigActor sigActors[TP_MAXSIGNALS];
                   ^~~~~~~~~
cc1: all warnings being treated as errors
Makefile:62: recipe for target 'build/tp-timers.o' failed
make: *** [build/tp-timers.o] Error 1
```

When looking online for this issue I found this https://stackoverflow.com/questions/4136939/where-is-sigunused-exactly-defined-in-header-files
It looks like since glibc 2.26 SIGUNUSED has been removed.